### PR TITLE
Fix component test using deprecated `.state`

### DIFF
--- a/blueprints/component-test/files/tests/unit/components/__test__.coffee
+++ b/blueprints/component-test/files/tests/unit/components/__test__.coffee
@@ -10,8 +10,8 @@ test 'it renders', ->
 
   # creates the component instance
   component = @subject()
-  equal component.state, 'preRender'
+  equal component._state, 'preRender'
 
   # appends the component to the page
   @append()
-  equal component.state, 'inDOM'
+  equal component._state, 'inDOM'


### PR DESCRIPTION
Hey @kimroen not sure if you have a way to sync blueprints from ember-cli or we need to fix them on a case-by-case basis? If you have a sync setup then they just need to be re-synced. Otherwise this changes just the component test blueprint to fix a deprecated warning but i notice that some other blueprints are outdated as well.

Fix:
`_state` instead of `state`
