### PR TITLE
Update test blueprints to reflect qunit 2.0 compatibility

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
@@ -3,8 +3,8 @@
 
 application = null
 
-module 'Acceptance: <%= classifiedModuleName %>',
-  setup: ->
+QUnit.module 'Acceptance: <%= classifiedModuleName %>',
+  beforeEach: ->
     application = startApp()
     ###
     Don't return as Ember.Application.then is deprecated.
@@ -13,11 +13,11 @@ module 'Acceptance: <%= classifiedModuleName %>',
     ###
     return
 
-  teardown: ->
+  afterEach: ->
     Ember.run application, 'destroy'
 
-test 'visiting /<%= dasherizedModuleName %>', ->
+QUnit.test 'visiting /<%= dasherizedModuleName %>', (assert) ->
   visit '/<%= dasherizedModuleName %>'
 
   andThen ->
-    equal currentPath(), '<%= dasherizedModuleName %>'
+    assert.equal currentPath(), '<%= dasherizedModuleName %>'

--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
@@ -1,9 +1,10 @@
 `import Ember from 'ember'`
+`import { module, test } from 'qunit'`
 `import startApp from '../helpers/start-app'`
 
 application = null
 
-QUnit.module 'Acceptance: <%= classifiedModuleName %>',
+module 'Acceptance: <%= classifiedModuleName %>',
   beforeEach: ->
     application = startApp()
     ###
@@ -16,7 +17,7 @@ QUnit.module 'Acceptance: <%= classifiedModuleName %>',
   afterEach: ->
     Ember.run application, 'destroy'
 
-QUnit.test 'visiting /<%= dasherizedModuleName %>', (assert) ->
+test 'visiting /<%= dasherizedModuleName %>', (assert) ->
   visit '/<%= dasherizedModuleName %>'
 
   andThen ->

--- a/blueprints/adapter-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/adapter-test/files/tests/unit/__path__/__test__.coffee
@@ -6,6 +6,6 @@ moduleFor 'adapter:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Ada
 }
 
 # Replace this with your real tests.
-test 'it exists', ->
+test 'it exists', (assert) ->
   adapter = @subject()
-  ok adapter
+  assert.ok adapter

--- a/blueprints/component-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/component-test/files/tests/unit/__path__/__test__.coffee
@@ -5,13 +5,13 @@ moduleForComponent '<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Co
   # needs: ['component:foo', 'helper:bar']
 }
 
-test 'it renders', ->
-  expect 2
+test 'it renders', (assert) ->
+  assert.expect 2
 
   # creates the component instance
   component = @subject()
-  equal component._state, 'preRender'
+  assert.equal component._state, 'preRender'
 
-  # appends the component to the page
-  @append()
-  equal component._state, 'inDOM'
+  # renders the component to the page
+  @render()
+  assert.equal component._state, 'inDOM'

--- a/blueprints/controller-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/controller-test/files/tests/unit/__path__/__test__.coffee
@@ -6,7 +6,7 @@ moduleFor 'controller:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>
 }
 
 # Replace this with your real tests.
-test 'it exists', ->
+test 'it exists', (assert) ->
   controller = @subject()
-  ok controller
+  assert.ok controller
 

--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.coffee
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.coffee
@@ -1,8 +1,9 @@
 `import { <%= camelizedModuleName %> } from '../../../helpers/<%= dasherizedModuleName %>'`
+`import { module, test } from 'qunit'`
 
-QUnit.module '<%= classifiedModuleName %>Helper'
+module '<%= classifiedModuleName %>Helper'
 
 # Replace this with your real tests.
-QUnit.test 'it works', (assert) ->
+test 'it works', (assert) ->
   result = <%= camelizedModuleName %> 42
   assert.ok result

--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.coffee
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.coffee
@@ -1,8 +1,8 @@
 `import { <%= camelizedModuleName %> } from '../../../helpers/<%= dasherizedModuleName %>'`
 
-module '<%= classifiedModuleName %>Helper'
+QUnit.module '<%= classifiedModuleName %>Helper'
 
 # Replace this with your real tests.
-test 'it works', ->
+QUnit.test 'it works', (assert) ->
   result = <%= camelizedModuleName %> 42
-  ok result
+  assert.ok result

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee
@@ -4,16 +4,16 @@
 container = null
 application = null
 
-module '<%= classifiedModuleName %>Initializer',
-  setup: ->
+QUnit.module '<%= classifiedModuleName %>Initializer',
+  beforeEach: ->
     Ember.run ->
       application = Ember.Application.create()
       container = application.__container__
       application.deferReadiness()
 
 # Replace this with your real tests.
-test 'it works', ->
+QUnit.test 'it works', (assert) ->
   initialize container, application
 
   # you would normally confirm the results of the initializer here
-  ok true
+  assert.ok true

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee
@@ -1,10 +1,11 @@
 `import Ember from 'ember'`
 `import { initialize } from '../../../initializers/<%= dasherizedModuleName %>'`
+`import { module, test } from 'qunit'`
 
 container = null
 application = null
 
-QUnit.module '<%= classifiedModuleName %>Initializer',
+module '<%= classifiedModuleName %>Initializer',
   beforeEach: ->
     Ember.run ->
       application = Ember.Application.create()
@@ -12,7 +13,7 @@ QUnit.module '<%= classifiedModuleName %>Initializer',
       application.deferReadiness()
 
 # Replace this with your real tests.
-QUnit.test 'it works', (assert) ->
+test 'it works', (assert) ->
   initialize container, application
 
   # you would normally confirm the results of the initializer here

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.coffee
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.coffee
@@ -1,10 +1,11 @@
 `import Ember from 'ember'`
 `import <%= classifiedModuleName %>Mixin from '../../../mixins/<%= dasherizedModuleName %>'`
+`import { module, test } from 'qunit'`
 
-QUnit.module '<%= classifiedModuleName %>Mixin'
+module '<%= classifiedModuleName %>Mixin'
 
 # Replace this with your real tests.
-QUnit.test 'it works', (assert) ->
+test 'it works', (assert) ->
   <%= classifiedModuleName %>Object = Ember.Object.extend <%= classifiedModuleName %>Mixin
   subject = <%= classifiedModuleName %>Object.create()
   assert.ok subject

--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.coffee
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.coffee
@@ -1,10 +1,10 @@
 `import Ember from 'ember'`
 `import <%= classifiedModuleName %>Mixin from '../../../mixins/<%= dasherizedModuleName %>'`
 
-module '<%= classifiedModuleName %>Mixin'
+QUnit.module '<%= classifiedModuleName %>Mixin'
 
 # Replace this with your real tests.
-test 'it works', ->
+QUnit.test 'it works', (assert) ->
   <%= classifiedModuleName %>Object = Ember.Object.extend <%= classifiedModuleName %>Mixin
   subject = <%= classifiedModuleName %>Object.create()
-  ok subject
+  assert.ok subject

--- a/blueprints/model-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.coffee
@@ -5,7 +5,7 @@ moduleForModel '<%= dasherizedModuleName %>', '<%= classifiedModuleName %>', {
 <%= typeof needs !== 'undefined' ? needs : '' %>
 }
 
-test 'it exists', ->
+test 'it exists', (assert) ->
   model = @subject()
   # store = @store()
-  ok !!model
+  assert.ok !!model

--- a/blueprints/route-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.coffee
@@ -5,6 +5,6 @@ moduleFor 'route:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Route
   # needs: ['controller:foo']
 }
 
-test 'it exists', ->
+test 'it exists', (assert) ->
   route = @subject()
-  ok route
+  assert.ok route

--- a/blueprints/serializer-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/serializer-test/files/tests/unit/__path__/__test__.coffee
@@ -6,6 +6,6 @@ moduleFor 'serializer:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>
 }
 
 # Replace this with your real tests.
-test 'it exists', ->
+test 'it exists', (assert) ->
   serializer = @subject()
-  ok serializer
+  assert.ok serializer

--- a/blueprints/service-test/files/tests/unit/services/__name__-test.coffee
+++ b/blueprints/service-test/files/tests/unit/services/__name__-test.coffee
@@ -6,6 +6,6 @@ moduleFor 'service:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>Ser
 }
 
 # Replace this with your real tests.
-test 'it exists', ->
+test 'it exists', (assert) ->
   service = @subject()
-  ok service
+  assert.ok service

--- a/blueprints/transform-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/transform-test/files/tests/unit/__path__/__test__.coffee
@@ -6,6 +6,6 @@ moduleFor 'transform:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>T
 }
 
 # Replace this with your real tests.
-test 'it exists', ->
+test 'it exists', (assert) ->
   transform = @subject()
-  ok transform
+  assert.ok transform

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.coffee
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.coffee
@@ -1,8 +1,8 @@
 `import <%= camelizedModuleName %> from '../../../utils/<%= dasherizedModuleName %>'`
 
-module '<%= camelizedModuleName %>'
+QUnit.module '<%= camelizedModuleName %>'
 
 # Replace this with your real tests.
-test 'it works', ->
+QUnit.test 'it works', (assert) ->
   result = <%= camelizedModuleName %>()
-  ok result
+  assert.ok result

--- a/blueprints/util-test/files/tests/unit/utils/__name__-test.coffee
+++ b/blueprints/util-test/files/tests/unit/utils/__name__-test.coffee
@@ -1,8 +1,9 @@
 `import <%= camelizedModuleName %> from '../../../utils/<%= dasherizedModuleName %>'`
+`import { module, test } from 'qunit'`
 
-QUnit.module '<%= camelizedModuleName %>'
+module '<%= camelizedModuleName %>'
 
 # Replace this with your real tests.
-QUnit.test 'it works', (assert) ->
+test 'it works', (assert) ->
   result = <%= camelizedModuleName %>()
   assert.ok result

--- a/blueprints/view-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/view-test/files/tests/unit/__path__/__test__.coffee
@@ -3,6 +3,6 @@
 moduleFor 'view:<%= dasherizedModuleName %>', '<%= classifiedModuleName %>View'
 
 # Replace this with your real tests.
-test 'it exists', ->
+test 'it exists', (assert) ->
   view = @subject()
-  ok view
+  assert.ok view


### PR DESCRIPTION
This commit should keep the blueprints up to date with recent changes in ember-cli meant to coincide with new qunit deprecations.

See commit here: https://github.com/ember-cli/ember-cli/commit/c35e35810b420f8a9df637db12ed4152c963aa62

This can probably wait until the next ember-cli version is released containing the new test blueprints.