### PR TITLE
Use current environment for config

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
       }
       brocfileConfig = this.app.options.coffeeOptions || {};
     }
-    var coffeeOptions = defaults(this.project.config('development').coffeeOptions || {},
+    var coffeeOptions = defaults(this.project.config(process.env.EMBER_ENV).coffeeOptions || {},
       brocfileConfig, {
         blueprints: true
       });


### PR DESCRIPTION
Instead of hard-coding `'development'`. Dummy.

Fixes #53