### PR TITLE
Add parameters for initializer function as comment

### DIFF
--- a/blueprints/initializer/files/app/initializers/__name__.coffee
+++ b/blueprints/initializer/files/app/initializers/__name__.coffee
@@ -1,5 +1,5 @@
 # Takes two parameters: container and app
-initialize = () ->
+initialize = (### container, application ###) ->
   # app.register 'route', 'foo', 'service:foo'
 
 <%= classifiedModuleName %>Initializer =


### PR DESCRIPTION
I noticed that the blueprinted function had no parameters and I kept looking which of them came first. I then saw that the original one had the parameters as comments and added them here as well.