### PR TITLE
Fix filtering to use coffeescript extensions

### DIFF
--- a/lib/coffee-preprocessor.js
+++ b/lib/coffee-preprocessor.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 
 function CoffeePreprocessor(options) {
   this.name = 'ember-cli-coffeescript';
-  this.ext = 'js';
+  this.ext = coffee.prototype.extensions;
   this.options = options || {};
 }
 

--- a/lib/coffee-preprocessor.js
+++ b/lib/coffee-preprocessor.js
@@ -4,9 +4,10 @@ var fs = require('fs');
 
 function CoffeePreprocessor(options) {
   this.name = 'ember-cli-coffeescript';
-  this.ext = coffee.prototype.extensions;
   this.options = options || {};
 }
+
+CoffeePreprocessor.prototype.ext = coffee.prototype.extensions;
 
 CoffeePreprocessor.prototype.toTree = function(tree, inputPath, outputPath) {
 


### PR DESCRIPTION
I might be totally off base here, so feel free to let me know.

It seems that this extension should be the source extension, not the target extension. It is ultimately used by `extensionsForType` inside ember-cli to build a regex pattern of files to search for, and when it's set to `js`, the regex completely misses the Coffeescript source files, and the files are never preprocessed / included in the build output.

This `extensionsForType` codepath doesn't seem to execute for the `/app` folder, but does on the `addon` folder. This previously didn't matter, since pre 0.2.0-beta.1, nested addon preprocessors weren't supported. But now that they are, it seems this is required.

I'm still wrapping my head around the nested addon stuff, so let me know if I missed something obvious on this one.