### PR TITLE
add before key to package.json to run ember-cli-coffeescript before ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,10 @@
     "ignore": "^2.2.15",
     "inflection": "^1.4.0",
     "lodash": "^2.4.1"
+  },
+  "ember-addon": {
+    "before": [
+      "ember-cli-babel"
+    ]
   }
 }


### PR DESCRIPTION
Coffeescript supports es6, and babel supports es6 -> es5, so it makes sense to pipe coffee's output to babel so we can finally be one step closer to using generators in our coffee code ( we will be able to experience true harmony once https://github.com/babel/ember-cli-babel/issues/24 is taken care of by the Wonder Women of the JS Justice League, @stefanpenner ). 

Meanwhile, the piping can be done with a simple change the package.json.