### PR TITLE
Updated ember-cli version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "broccoli-filter": "~0.1.10",
     "chalk": "^1.0.0",
     "coffeelint": "^1.6.1",
-    "ember-cli": "^0.2.0",
+    "ember-cli": "^1.13.0",
     "ember-cli-version-checker": "^1.0.1",
     "fs-extra": "^0.11.1",
     "ignore": "^2.2.15",


### PR DESCRIPTION
Gets rid of warnings on npm install:

    npm WARN unmet dependency /Users/dixon/.nvm/versions/io.js/v2.3.4/lib/node_modules/adstage-core/node_modules/ember-cli-coffeescript requires ember-cli@'^0.2.0' but will load
    npm WARN unmet dependency /Users/dixon/.nvm/versions/io.js/v2.3.4/lib/node_modules/adstage-core/node_modules/ember-cli,
    npm WARN unmet dependency which is version 1.13.1