### PR TITLE
Fix for issue with recent versions of ember-cli (Cannot read property 'dummy' of undefined)

### DIFF
--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -27,14 +27,14 @@ module.exports = {
     this.lookupBlueprint('route').beforeInstall(options);
   },
 
-  shouldTouchRouter: function(name) {
-    return this.lookupBlueprint('route').shouldTouchRouter(name);
+  shouldTouchRouter: function(name, options) {
+    return this.lookupBlueprint('route').shouldTouchRouter(name, options);
   },
 
   afterInstall: function(options) {
     var entity = options.entity;
 
-    if (this.shouldTouchRouter(entity.name) && !options.dryRun) {
+    if (this.shouldTouchRouter(entity.name, options) && !options.dryRun) {
       addRouteToRouter(entity.name, {
         type: options.type,
         root: options.project.root
@@ -49,7 +49,7 @@ module.exports = {
   afterUninstall: function(options) {
     var entity = options.entity;
 
-    if (this.shouldTouchRouter(entity.name) && !options.dryRun) {
+    if (this.shouldTouchRouter(entity.name, options) && !options.dryRun) {
       removeRouteFromRouter(entity.name, {
         type: options.type,
         root: options.project.root


### PR DESCRIPTION
With the most recent versions of `ember-cli`, you get exceptions like this when doing `ember destroy route` or `ember generate route`.

```
$ ember destroy route foo
version: 1.13.6
Could not find watchman, falling back to NodeWatcher for file system events.
Visit http://www.ember-cli.com/user-guide/#watchman for more info.
uninstalling route
  remove app/routes/foo.coffee
  remove app/templates/foo.hbs
Cannot read property 'dummy' of undefined
TypeError: Cannot read property 'dummy' of undefined
  at Class.module.exports.shouldTouchRouter (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli/blueprints/route/index.js:66:28)
  at Class.module.exports.shouldTouchRouter (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli-coffeescript/blueprints/route/index.js:31:42)
  at Class.module.exports.shouldTouchRouter (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli-coffeescript/blueprints/route/index.js:31:42)
  at Class.module.exports.afterUninstall (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli-coffeescript/blueprints/route/index.js:52:14)

  at lib$rsvp$$internal$$tryCatch (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:493:16)
  at lib$rsvp$$internal$$invokeCallback (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:505:17)
  at lib$rsvp$$internal$$publish (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:476:11)
  at lib$rsvp$asap$$flush (/Users/plundberg/tmp/ember-cli-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1198:9)
  at process._tickCallback (node.js:355:11)
```

The problem was that `shouldTouchRouter` now assumes that it will get the `options` object passed in as a parameter. This commit fixes this. (thanks to @mriska for helping me out to nail this one down)