### PR TITLE
Upgrade node-ignore -> 3.x to solve several known issues.

### DIFF
--- a/lib/coffee-linter.js
+++ b/lib/coffee-linter.js
@@ -71,7 +71,9 @@ function CoffeeScriptLinter (inputTree, options) {
   }
 
   if(fs.existsSync("./.coffeelintignore")) {
-    this.coffeelintignore = ignore().addIgnoreFile('./.coffeelintignore').createFilter();
+    this.coffeelintignore = ignore()
+      .add(fs.readFileSync('./.coffeelintignore').toString())
+      .createFilter();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "coffeelint": "^1.6.1",
     "ember-cli-version-checker": "^1.0.1",
     "fs-extra": "^0.11.1",
-    "ignore": "^2.2.15",
+    "ignore": "^3.0.9",
     "inflection": "^1.4.0",
     "json-stable-stringify": "^1.0.0",
     "lodash": "^2.4.1"


### PR DESCRIPTION
Upgrades [`node-ignore`](https://www.npmjs.com/package/ignore) to the latest `3.0.9` to solve several known issues, including:

- Files should not be re-included if the parent directory is ignored, [#10](https://github.com/kaelzhang/node-ignore/issues/10)
- Works for [windows](https://ci.appveyor.com/project/kaelzhang/node-ignore), finally. [#5](https://github.com/kaelzhang/node-ignore/issues/5)
- Better Handling with trailing whitespaces, wildcards of ignore patterns, according to [gitignore spec](https://git-scm.com/docs/gitignore), and passed all cases described in the spec.