### PR TITLE
Fix blueprints: dependencyDepth is not defined

### DIFF
--- a/blueprints/helper-test/files/tests/unit/helpers/__name__-test.coffee
+++ b/blueprints/helper-test/files/tests/unit/helpers/__name__-test.coffee
@@ -1,4 +1,4 @@
-`import { <%= camelizedModuleName %> } from '<%= dependencyDepth %>/helpers/<%= dasherizedModuleName %>'`
+`import { <%= camelizedModuleName %> } from '<%= dasherizedModulePrefix %>/helpers/<%= dasherizedModuleName %>'`
 `import { module, test } from 'qunit'`
 
 module '<%= friendlyTestName %>'

--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee
@@ -1,5 +1,5 @@
 `import Ember from 'ember'`
-`import { initialize } from '<%= dependencyDepth %>/initializers/<%= dasherizedModuleName %>'`
+`import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>'`
 `import { module, test } from 'qunit'`
 
 application = null


### PR DESCRIPTION
When using the generators for `helpers-test` or `initializers-test` I was getting the following error:
```
➜  cs-test git:(master) ✗ ember generate initializer-test foo
version: 2.3.0
installing initializer-test
  create tests/unit/initializers/foo-test.coffee
dependencyDepth is not defined (Error in blueprint template: /Users/mriska/work/ember-cli-coffeescript/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee)
ReferenceError: dependencyDepth is not defined (Error in blueprint template: /Users/mriska/work/ember-cli-coffeescript/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.coffee)
  at eval (<anonymous>:8:11)
  at processTemplate (/Users/mriska/work/cs-test/node_modules/ember-cli/lib/models/file-info.js:19:36)
  at /Users/mriska/work/cs-test/node_modules/ember-cli/lib/models/file-info.js:100:20
  at lib$rsvp$$internal$$tryCatch (/Users/mriska/work/cs-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1036:16)
  at lib$rsvp$$internal$$invokeCallback (/Users/mriska/work/cs-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1048:17)
  at lib$rsvp$$internal$$publish (/Users/mriska/work/cs-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1019:11)
  at lib$rsvp$asap$$flush (/Users/mriska/work/cs-test/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1198:9)
  at _combinedTickCallback (internal/process/next_tick.js:67:7)
  at process._tickCallback (internal/process/next_tick.js:98:9)
```
The following changes to the blueprint seems to fix that error. `dasherizedModulePrefix` is what is being used in the standard `ember-cli` blueprints.