### PR TITLE
Remove blueprints for view and view-test

### DIFF
--- a/blueprints/view-test/files/tests/unit/__path__/__test__.coffee
+++ b/blueprints/view-test/files/tests/unit/__path__/__test__.coffee
@@ -1,8 +1,0 @@
-`import { moduleFor, test } from 'ember-qunit'`
-
-moduleFor 'view:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>'
-
-# Replace this with your real tests.
-test 'it exists', (assert) ->
-  view = @subject()
-  assert.ok view

--- a/blueprints/view-test/index.js
+++ b/blueprints/view-test/index.js
@@ -1,1 +1,0 @@
-module.exports = require('ember-cli/blueprints/view-test');

--- a/blueprints/view/files/__root__/__path__/__name__.coffee
+++ b/blueprints/view/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,0 @@
-`import Ember from 'ember'`
-
-<%= classifiedModuleName %>View = Ember.View.extend()
-
-`export default <%= classifiedModuleName %>View`

--- a/blueprints/view/index.js
+++ b/blueprints/view/index.js
@@ -1,1 +1,0 @@
-module.exports = require('ember-cli/blueprints/view');


### PR DESCRIPTION
They are removed in ember-cli as of 2.4.3 https://github.com/ember-cli/ember-cli/pull/5607
And having them in ember-cli-coffeescript gives errors if using a never version of ember-cli in the same project

```
Cannot find module 'ember-cli/blueprints/view'
Error: Cannot find module 'ember-cli/blueprints/view'
  at Function.Module._resolveFilename (module.js:339:15)
  at Function.Module._load (module.js:290:25)
  at Module.require (module.js:367:17)
  at require (internal/module.js:20:19)
  at Object.<anonymous> (/Users/mriska/work/test3/node_modules/ember-cli-coffeescript/blueprints/view/index.js:1:80)
```