### PR TITLE
Manually append legacy blueprints

### DIFF
--- a/lib/utilities/ancestral-blueprint.js
+++ b/lib/utilities/ancestral-blueprint.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Blueprint = require('ember-cli/lib/models/blueprint');
+var path = require('path');
 
 /**
   Find the non-coffeescript version of the blueprint to bootstrap off
@@ -12,7 +13,18 @@ module.exports = function(dasherizedName, project) {
     return !p.match(/ember-cli-coffeescript/);
   });
 
+  projectPaths = projectPaths.concat(legacyBlueprintsPath());
+
   return Blueprint.lookup(dasherizedName, {
     paths: projectPaths
   });
 };
+
+function legacyBlueprintsPath() {
+  return path.join(
+    path.dirname(
+      require.resolve('ember-cli-legacy-blueprints')
+    ),
+    'blueprints'
+  );
+}


### PR DESCRIPTION
On older versions of ember-cli, before ember-cli-legacy-blueprints was added, this new setup of fetching the ancestral blueprint didn’t work.

We resolve this by manually adding the legacy blueprints path that ember-cli-coffeescript depends on to the list of paths to check. If it is already present, it will be deduplicated by ember-cli.

This extends the work done in #115