### PR TITLE
Run after ember and ember data

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
     "configPath": "tests/dummy/config",
     "before": [
       "ember-cli-babel"
+    ],
+    "after": [
+      "ember",
+      "ember-data"
     ]
   }
 }


### PR DESCRIPTION
We use blueprints from these addons, so we want to make sure we come after them in the list of blueprints to resolve.

Fixes #86