### PR TITLE
Check specific ember-cli-coffeescript path

### DIFF
--- a/lib/utilities/ancestral-blueprint.js
+++ b/lib/utilities/ancestral-blueprint.js
@@ -2,6 +2,7 @@
 
 var Blueprint = require('ember-cli/lib/models/blueprint');
 var path = require('path');
+var coffeeScriptPath = path.resolve(__dirname, '../..', 'blueprints');
 
 /**
   Find the non-coffeescript version of the blueprint to bootstrap off
@@ -10,7 +11,7 @@ module.exports = function(dasherizedName, project) {
   var projectPaths = project ? project.blueprintLookupPaths() : [];
 
   projectPaths = projectPaths.filter(function(p) {
-    return !p.match(/ember-cli-coffeescript/);
+    return p !== coffeeScriptPath;
   });
 
   projectPaths = projectPaths.concat(legacyBlueprintsPath());


### PR DESCRIPTION
Instead of discarding all paths that contains `ember-cli-coffeescript`, we now look for the specific path of this package.

I ran in to this when testing things in a folder called `ember-cli-coffeescript-test` and getting some unexpected results.