### PR TITLE
Simplified exports in blueprints

### DIFF
--- a/blueprints/adapter/files/__root__/__path__/__name__.coffee
+++ b/blueprints/adapter/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,3 @@
 <%= importStatement %>
 
-<%= classifiedModuleName %>Adapter = <%= baseClass %>.extend()
-
-export default <%= classifiedModuleName %>Adapter
+export default <%= baseClass %>.extend()

--- a/blueprints/component/files/__root__/__path__/__name__.coffee
+++ b/blueprints/component/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,3 @@
 import Ember from 'ember'
 <%= importTemplate %>
-<%= classifiedModuleName %>Component = Ember.Component.extend(<%=contents%>)
-
-export default <%= classifiedModuleName %>Component
+export default Ember.Component.extend(<%=contents%>)

--- a/blueprints/controller/files/__root__/__path__/__name__.coffee
+++ b/blueprints/controller/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,3 @@
 import Ember from 'ember'
 
-<%= classifiedModuleName %>Controller = Ember.Controller.extend()
-
-export default <%= classifiedModuleName %>Controller
+export default Ember.Controller.extend()

--- a/blueprints/helper/files/__root__/helpers/__name__.coffee
+++ b/blueprints/helper/files/__root__/helpers/__name__.coffee
@@ -1,11 +1,7 @@
 import Ember from 'ember'
 
 # This function receives the params `params, hash`
-<%= camelizedModuleName %> = (params) ->
+export <%= camelizedModuleName %> = (params) ->
   return params
 
-<%= classifiedModuleName %>Helper = Ember.Helper.helper <%= camelizedModuleName %>
-
-export { <%= camelizedModuleName %> }
-
-export default <%= classifiedModuleName %>Helper
+export default Ember.Helper.helper <%= camelizedModuleName %>

--- a/blueprints/mixin/files/__root__/mixins/__name__.coffee
+++ b/blueprints/mixin/files/__root__/mixins/__name__.coffee
@@ -1,5 +1,3 @@
 import Ember from 'ember'
 
-<%= classifiedModuleName %>Mixin = Ember.Mixin.create()
-
-export default <%= classifiedModuleName %>Mixin
+export default Ember.Mixin.create()

--- a/blueprints/model/files/__root__/__path__/__name__.coffee
+++ b/blueprints/model/files/__root__/__path__/__name__.coffee
@@ -1,7 +1,5 @@
 import DS from 'ember-data'
 
-<%= classifiedModuleName %> = DS.Model.extend {
+export default DS.Model.extend {
   <%= attrs %>
 }
-
-export default <%= classifiedModuleName %>

--- a/blueprints/route/files/__root__/__path__/__name__.coffee
+++ b/blueprints/route/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,3 @@
 import Ember from 'ember'
 
-<%= classifiedModuleName %>Route = Ember.Route.extend()
-
-export default <%= classifiedModuleName %>Route
+export default Ember.Route.extend()

--- a/blueprints/serializer/files/__root__/__path__/__name__.coffee
+++ b/blueprints/serializer/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,3 @@
 import DS from 'ember-data'
 
-<%= classifiedModuleName %>Serializer = DS.RESTSerializer.extend()
-
-export default <%= classifiedModuleName %>Serializer
+export default DS.RESTSerializer.extend()

--- a/blueprints/service/files/__root__/__path__/__name__.coffee
+++ b/blueprints/service/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,3 @@
 import Ember from 'ember'
 
-<%= classifiedModuleName %>Service = Ember.Service.extend()
-
-export default <%= classifiedModuleName %>Service
+export default Ember.Service.extend()

--- a/blueprints/transform/files/__root__/__path__/__name__.coffee
+++ b/blueprints/transform/files/__root__/__path__/__name__.coffee
@@ -1,10 +1,8 @@
 import DS from 'ember-data'
 
-<%= classifiedModuleName %>Transform = DS.Transform.extend
+export default DS.Transform.extend
   deserialize: (serialized) ->
     serialized
 
   serialize: (deserialized) ->
     deserialized
-
-export default <%= classifiedModuleName %>Transform

--- a/blueprints/util/files/__root__/utils/__name__.coffee
+++ b/blueprints/util/files/__root__/utils/__name__.coffee
@@ -1,4 +1,2 @@
-<%= camelizedModuleName %> = () ->
+export default () ->
   true
-
-export default <%= camelizedModuleName %>

--- a/blueprints/view/files/__root__/__path__/__name__.coffee
+++ b/blueprints/view/files/__root__/__path__/__name__.coffee
@@ -1,5 +1,3 @@
 import Ember from 'ember'
 
-<%= classifiedModuleName %>View = Ember.View.extend()
-
-export default <%= classifiedModuleName %>View
+export default Ember.View.extend()

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy adapter', function() {
 
         expect(adapterFile)
           .to.contain("import ApplicationAdapter from './application'")
-          .to.contain("FooAdapter = ApplicationAdapter.extend()")
-          .to.contain("export default FooAdapter");
+          .to.contain('export default ApplicationAdapter.extend()');
 
         expectCoffee(adapterFile);
 

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy component', function() {
 
         expect(componentFile)
           .to.contain("import Ember from 'ember'")
-          .to.contain('XFooComponent = Ember.Component.extend()')
-          .to.contain('export default XFooComponent')
+          .to.contain('export default Ember.Component.extend()')
           .to.not.contain('layout');
 
         expectCoffee(componentFile);

--- a/node-tests/blueprints/controller-test.js
+++ b/node-tests/blueprints/controller-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
 
         expect(controllerFile)
           .to.contain("import Ember from 'ember'")
-          .to.contain('FooController = Ember.Controller.extend()')
-          .to.contain("export default FooController");
+          .to.contain('export default Ember.Controller.extend()');
 
         expectCoffee(controllerFile);
 

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -20,10 +20,8 @@ describe('Acceptance: ember generate and destroy helper', function() {
 
         expect(helperFile)
           .to.contain("import Ember from 'ember'")
-          .to.contain('fooBar = (params) ->')
-          .to.contain('FooBarHelper = Ember.Helper.helper fooBar')
-          .to.contain("export { fooBar }")
-          .to.contain("export default FooBarHelper");
+          .to.contain('export fooBar = (params) ->')
+          .to.contain('export default Ember.Helper.helper fooBar');
 
         expectCoffee(helperFile);
 

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
 
         expect(mixinFile)
           .to.contain("import Ember from 'ember'")
-          .to.contain('FooBarMixin = Ember.Mixin.create()')
-          .to.contain("export default FooBarMixin");
+          .to.contain('export default Ember.Mixin.create()');
 
         expectCoffee(mixinFile);
 

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy model', function() {
 
         expect(modelFile)
           .to.contain("import DS from 'ember-data'")
-          .to.contain('Foo = DS.Model.extend {')
-          .to.contain("export default Foo");
+          .to.contain('export default DS.Model.extend {');
 
         expectCoffee(modelFile);
 

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy serializer', function() {
 
         expect(serializerFile)
           .to.contain("import DS from 'ember-data'")
-          .to.contain('FooSerializer = DS.RESTSerializer.extend()')
-          .to.contain("export default FooSerializer");
+          .to.contain('export default DS.RESTSerializer.extend()');
 
         expectCoffee(serializerFile);
 

--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy service', function() {
 
         expect(serviceFile)
           .to.contain("import Ember from 'ember'")
-          .to.contain('FooService = Ember.Service.extend()')
-          .to.contain("export default FooService");
+          .to.contain('export default Ember.Service.extend()');
 
         expectCoffee(serviceFile);
 

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy transform', function() {
 
         expect(transformFile)
           .to.contain("import DS from 'ember-data'")
-          .to.contain('FooTransform = DS.Transform.extend')
-          .to.contain("export default FooTransform");
+          .to.contain('export default DS.Transform.extend');
 
         expectCoffee(transformFile);
 

--- a/node-tests/blueprints/util-test.js
+++ b/node-tests/blueprints/util-test.js
@@ -19,8 +19,7 @@ describe('Acceptance: ember generate and destroy util', function() {
         var utilFile = file('app/utils/foo-bar.coffee');
 
         expect(utilFile)
-          .to.contain('fooBar = () ->')
-          .to.contain("export default fooBar");
+          .to.contain('export default () ->');
 
         expectCoffee(utilFile);
 

--- a/node-tests/blueprints/view-test.js
+++ b/node-tests/blueprints/view-test.js
@@ -20,8 +20,7 @@ describe('Acceptance: ember generate and destroy view', function() {
 
         expect(viewFile)
           .to.contain("import Ember from 'ember'")
-          .to.contain('FooView = Ember.View.extend()')
-          .to.contain("export default FooView");
+          .to.contain('export default Ember.View.extend()');
 
         expectCoffee(viewFile);
 


### PR DESCRIPTION
This PR changes the blueprints from using a named variable to doing  direct exports of the code. In addition to being more easy on the eyes, it fixes a problem with the compiled javascript file containing an undeclared variable in newer versions of the CoffeeScript compiler.

Fixes #135 
Fixes #134

I have tested to create all of the blueprints changed: 
```shell
ember g adapter foo-foo
ember g component foo-foo
ember g controller foo-foo
ember g helper foo-foo
ember g mixin foo-foo
ember g model foo-foo
ember g route foo-foo
ember g serializer foo-foo
ember g service foo-foo
ember g transform foo-foo
ember g util foo-foo
ember g view foo-foo
```

And the tests pass with the exception of `view` which I assume is due to the fact that a fairly recent Ember version is used which no longer supports `view`s. I guess this blueprint can be removed at some point unless we want to keep it for people using it with older Ember version. On the other hand a case can be made for not helping them to create code that is deprecated in newer versions of Ember.