### PR TITLE
Export initializers without intermediate variables

### DIFF
--- a/blueprints/initializer/files/__root__/initializers/__name__.coffee
+++ b/blueprints/initializer/files/__root__/initializers/__name__.coffee
@@ -1,10 +1,8 @@
 # Takes two parameters: container and application
-initialize = () ->
+export initialize = () ->
   # application.register 'route', 'foo', 'service:foo'
 
-<%= classifiedModuleName %>Initializer =
+export default {
   name: '<%= dasherizedModuleName %>'
   initialize: initialize
-
-export {initialize}
-export default <%= classifiedModuleName %>Initializer
+}

--- a/node-tests/blueprints/initializer-test.js
+++ b/node-tests/blueprints/initializer-test.js
@@ -19,11 +19,10 @@ describe('Acceptance: ember generate and destroy initializer', function() {
         var initializerFile = file('app/initializers/foo-bar.coffee');
 
         expect(file('app/initializers/foo-bar.coffee'))
-          .to.contain('initialize = () ->')
-          .to.contain('FooBarInitializer =')
+          .to.contain('export initialize = () ->')
+          .to.contain('export default {')
           .to.contain("name: 'foo-bar'")
-          .to.contain("export {initialize}")
-          .to.contain("export default FooBarInitializer");
+          .to.contain("initialize: initialize");
 
         expectCoffee(initializerFile);
 


### PR DESCRIPTION
This PR fixes one remaining generator that did not export its variables directly.

This was an oversight in #137 