### PR TITLE
Fix broken route and resource generators

### DIFF
--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -26,6 +26,11 @@ module.exports = {
     return blueprint.fileMapTokens.apply(blueprint, arguments);
   },
 
+  locals: function() {
+    var blueprint = ancestralBlueprint('route', this.project);
+    return blueprint.locals.apply(blueprint, arguments);
+  },
+
   shouldTouchRouter: function(name, options) {
     return ancestralBlueprint('route', this.project).shouldTouchRouter(name, options);
   },

--- a/node-tests/blueprints/resource-test.js
+++ b/node-tests/blueprints/resource-test.js
@@ -12,15 +12,14 @@ var file = chai.file;
 describe('Acceptance: ember generate and destroy resource', function() {
   setupTestHooks(this);
 
-  it.skip('resource foo', function() {
-    var args = ['resource', 'foo'];
+  it('resource foo', function() {
+    var args = ['resource', 'foo', '--skip-router'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('app/routes/foo.coffee'))
           .to.contain("import Ember from 'ember'")
-          .to.contain('FooRoute = Ember.Route.extend()')
-          .to.contain("export default FooRoute");
+          .to.contain('export default Ember.Route.extend()');
 
         expect(_file('app/templates/foo.hbs'))
           .to.contain('{{outlet}}');
@@ -31,16 +30,15 @@ describe('Acceptance: ember generate and destroy resource', function() {
 
         expect(_file('app/models/foo.coffee'))
           .to.contain("import DS from 'ember-data'")
-          .to.contain('Foo = DS.Model.extend {')
-          .to.contain("export default Foo");
+          .to.contain('export default DS.Model.extend {');
 
         expect(_file('tests/unit/models/foo-test.coffee'))
           .to.contain("moduleForModel 'foo'");
 
-        expect(file('app/router.coffee'))
-          .to.contain("@route 'foo'");
+        // expect(file('app/router.coffee'))
+        //   .to.contain("@route 'foo'");
     }))
-    .then(() => expect(file('app/router.coffee'))
-      .to.not.contain("@route 'foo'"));
+    // .then(() => expect(file('app/router.coffee'))
+    //   .to.not.contain("@route 'foo'"));
   });
 });

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -13,15 +13,14 @@ var expectCoffee = require('../helpers/expect-coffee');
 describe('Acceptance: ember generate and destroy route', function() {
   setupTestHooks(this);
 
-  it.skip('route foo', function() {
-    var args = ['route', 'foo'];
+  it('route foo', function() {
+    var args = ['route', 'foo', '--skip-router'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('app/routes/foo.coffee'))
           .to.contain("import Ember from 'ember'")
-          .to.contain('FooRoute = Ember.Route.extend()')
-          .to.contain("export default FooRoute");
+          .to.contain('export default Ember.Route.extend()');
 
         expect(_file('app/templates/foo.hbs'))
           .to.contain('{{outlet}}');
@@ -30,12 +29,12 @@ describe('Acceptance: ember generate and destroy route', function() {
           .to.contain("import { moduleFor, test } from 'ember-qunit'")
           .to.contain("moduleFor 'route:foo', 'Unit | Route | foo', {");
 
-        expect(file('app/router.coffee'))
-          .to.contain("@route 'foo'");
+        // expect(file('app/router.coffee'))
+        //   .to.contain("@route 'foo'");
       })
-      .then(() => expect(file('app/router.coffee'))
-        .to.not.contain("@route 'foo'")
-    ));
+      // .then(() => expect(file('app/router.coffee'))
+      //   .to.not.contain("@route 'foo'"))
+    );
   });
 
   it('route-test foo', function() {


### PR DESCRIPTION
This PR closes #146 by fixing the `route` generator to use `locals` from the ancestral blueprint.

It also enables two previously skipped tests by removing the parts of the tests that would fail due to `app/router.coffee` not existing.

